### PR TITLE
Add detailed assertions for v8 bone and animation tests

### DIFF
--- a/JBK.Tools.ModelLoader.Tests/GbFileLoaderTests.cs
+++ b/JBK.Tools.ModelLoader.Tests/GbFileLoaderTests.cs
@@ -48,6 +48,8 @@
             var model = GbFileLoader.LoadFromFile("TestFiles/v8_bone.gb");
 
             Assert.NotNull(model);
+            Assert.Equal(28, model.bones.Length);
+            Assert.Equal(255, model.bones[0].parent);
         }
 
         [Fact]
@@ -56,6 +58,13 @@
             var model = GbFileLoader.LoadFromFile("TestFiles/v8_animation_1.gb");
 
             Assert.NotNull(model);
+            Assert.Equal(1, model.header.AnimFileCount);
+            Assert.Single(model.Animations);
+            Assert.Equal(4u, model.header.KeyframeCount);
+            Assert.Equal(78u, model.header.AnimCount);
+            Assert.Equal((int)model.header.AnimCount, model.AllAnimationTransforms.Length);
+            Assert.Equal(model.Animations[0].Header.keyframe_count, model.Animations[0].Keyframes.Length);
+            Assert.Equal(model.header.BoneCount, model.Animations[0].BoneTransformIndices.GetLength(1));
         }
 
 


### PR DESCRIPTION
## Summary
- verify bone count and root parent in v8 bone parser tests
- validate animation headers and transform counts in v8 animation tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19c66e69c8331a60c3039d97435c4