### PR TITLE
Fix typo in HeightMap comment

### DIFF
--- a/JBK.Tools.MapExtractor/Maps/HeightMap.cs
+++ b/JBK.Tools.MapExtractor/Maps/HeightMap.cs
@@ -44,7 +44,7 @@ public class HeightMap : IMap
     }
 
     /// <summary>
-    /// Save with Magick.NET becuase GDI+ is not able to save 16-Bit Images
+    /// Save with Magick.NET because GDI+ is not able to save 16-Bit Images
     /// </summary>
     public void Save16BitHeightmap(string filePath)
     {


### PR DESCRIPTION
## Summary
- fix typo in HeightMap comment using correct "because" spelling

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a19c2f51a883319de836ed93a16462